### PR TITLE
do not duplicate option

### DIFF
--- a/Action/AutoCreateSubtask.php
+++ b/Action/AutoCreateSubtask.php
@@ -32,6 +32,7 @@ class AutoCreateSubtask extends Base
       'time_estimated' => t('Estimated Time in Hours'),
       'duration' => t('Duration in days'),
       'check_box' => t('Apply to all Columns'),
+      'duplicate' => t('Do not duplicate subtasks'),
     );
   }
 
@@ -63,11 +64,20 @@ class AutoCreateSubtask extends Base
       'due_date' => strtotime('+'.$this->getParam('duration').'days'),
     );
 
-    $subtasks = explode("\r\n", isset($values['title']) ? $values['title'] : '');
+    $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
+    
+    if ($this->getParam('duplicate') == true ){
+      $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
+      foreach ($current_subtasks as $current_subtask) {
+        if (in_array($current_subtask['title'], $subtasks)) {
+          $title = array_search($current_subtask['title'], $subtasks);
+          unset($subtasks[$title]);
+        }
+      }
+    }
 
     foreach ($subtasks as $subtask) {
-      $subtask = trim($subtask);
 
       if (! empty($subtask)) {
         $subtaskValues = $values;

--- a/Action/AutoCreateSubtask.php
+++ b/Action/AutoCreateSubtask.php
@@ -31,8 +31,8 @@ class AutoCreateSubtask extends Base
       'multitasktitles' => t('Subtask Title(s)'),
       'time_estimated' => t('Estimated Time in Hours'),
       'duration' => t('Duration in days'),
-      'check_box' => t('Apply to all Columns'),
-      'duplicate' => t('Do not duplicate subtasks'),
+      'check_box_all_columns' => t('Apply to all Columns'),
+      'check_box_no_duplicates' => t('Do not duplicate subtasks'),
     );
   }
 
@@ -67,7 +67,7 @@ class AutoCreateSubtask extends Base
     $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
     
-    if ($this->getParam('duplicate') == true ){
+    if ($this->getParam('check_box_no_duplicates') == true ){
       $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
       foreach ($current_subtasks as $current_subtask) {
         if (in_array($current_subtask['title'], $subtasks)) {
@@ -112,7 +112,7 @@ class AutoCreateSubtask extends Base
   public function hasRequiredCondition(array $data)
   {
     
-    if ($this->getParam('check_box')) {
+    if ($this->getParam('check_box_all_columns')) {
     return $data['task']['column_id'] == $data['task']['column_id'];
     } else {
     return $data['task']['column_id'] == $this->getParam('column_id');

--- a/Action/AutoCreateSubtaskVanilla.php
+++ b/Action/AutoCreateSubtaskVanilla.php
@@ -30,8 +30,8 @@ class AutoCreateSubtaskVanilla extends Base
       'user_id' => t('Assignee'),
       'multitasktitles' => t('Subtask Title(s)'),
       'time_estimated' => t('Estimated Time in Hours'),
-      'check_box' => t('Apply to all Columns'),
-      'duplicate' => t('Do not duplicate subtasks'),
+      'check_box_all_columns' => t('Apply to all Columns'),
+      'check_box_no_duplicates' => t('Do not duplicate subtasks'),
     );
   }
 
@@ -65,7 +65,7 @@ class AutoCreateSubtaskVanilla extends Base
     $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
     
-    if ($this->getParam('duplicate') == true ){
+    if ($this->getParam('check_box_no_duplicates') == true ){
       $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
       foreach ($current_subtasks as $current_subtask) {
         if (in_array($current_subtask['title'], $subtasks)) {
@@ -110,7 +110,7 @@ class AutoCreateSubtaskVanilla extends Base
   public function hasRequiredCondition(array $data)
   {
     
-    if ($this->getParam('check_box')) {
+    if ($this->getParam('check_box_all_columns')) {
     return $data['task']['column_id'] == $data['task']['column_id'];
     } else {
     return $data['task']['column_id'] == $this->getParam('column_id');

--- a/Action/AutoCreateSubtaskVanilla.php
+++ b/Action/AutoCreateSubtaskVanilla.php
@@ -31,6 +31,7 @@ class AutoCreateSubtaskVanilla extends Base
       'multitasktitles' => t('Subtask Title(s)'),
       'time_estimated' => t('Estimated Time in Hours'),
       'check_box' => t('Apply to all Columns'),
+      'duplicate' => t('Do not duplicate subtasks'),
     );
   }
 
@@ -61,11 +62,20 @@ class AutoCreateSubtaskVanilla extends Base
       'status' => 0,
     );
 
-    $subtasks = explode("\r\n", isset($values['title']) ? $values['title'] : '');
+    $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
+    
+    if ($this->getParam('duplicate') == true ){
+      $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
+      foreach ($current_subtasks as $current_subtask) {
+        if (in_array($current_subtask['title'], $subtasks)) {
+          $title = array_search($current_subtask['title'], $subtasks);
+          unset($subtasks[$title]);
+        }
+      }
+    }
 
     foreach ($subtasks as $subtask) {
-      $subtask = trim($subtask);
 
       if (! empty($subtask)) {
         $subtaskValues = $values;

--- a/Plugin.php
+++ b/Plugin.php
@@ -36,7 +36,7 @@ class Plugin extends Base
 
   public function getPluginVersion()
   {
-    return '1.0.4';
+    return '2.0.0';
   }
   
   public function getPluginDescription()


### PR DESCRIPTION
- Closes #6 
- Option to not duplicate subtasks of same title added
- Changed a variable name for "apply to all columns"
  - This will cause a breaking change to existing actions for those who upgrade, sorry, wanted to make the variable name more clear as to it's purpose.