### PR TITLE
Initial commit of new magical-parameters-feature

### DIFF
--- a/Action/AutoCreateSubtaskVanilla.php
+++ b/Action/AutoCreateSubtaskVanilla.php
@@ -64,7 +64,7 @@ class AutoCreateSubtaskVanilla extends Base
 
     $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
-    
+
     if ($this->getParam('check_box_no_duplicates') == true ){
       $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
       foreach ($current_subtasks as $current_subtask) {
@@ -79,7 +79,18 @@ class AutoCreateSubtaskVanilla extends Base
 
       if (! empty($subtask)) {
         $subtaskValues = $values;
-        $subtaskValues['title'] = $subtask;
+
+        // *** Parsing for "magical" parameters ... enabling separate values for each subtask ***
+        // Extract subtask-title by ignoring all "magical" parameters
+        $subtaskValues['title'] = preg_replace('~.*?}~', '', $subtask);
+
+        // Extracting optional assignee for this subtask ELSE assignee from form will be used
+        $magic_user_id_exists = preg_match('/{u:(.*?)}/', $subtask, $magic_user_id);
+        $subtaskValues['user_id'] = ($magic_user_id_exists) ? $magic_user_id[1] : $subtaskValues['user_id'];
+
+        // Extracting optional estimated hours for this subtask ELSE estimated hours from form will be used
+        $magic_time_exists = preg_match('/{h:(.*?)}/', $subtask, $magic_time);
+        $subtaskValues['time_estimated'] = ($magic_time_exists) ? $magic_time[1] : $subtaskValues['time_estimated'];
 
         list($valid, $errors) = $this->subtaskValidator->validateCreation($subtaskValues);
 
@@ -97,7 +108,7 @@ class AutoCreateSubtaskVanilla extends Base
         $subtasksAdded++;
       }
     }
-    //restore the messaging with a flash but this message doesn't seem to appear in the flash area. Only the create message from (kanboard/app/Controller/ActionCreationController.php). 
+    //restore the messaging with a flash but this message doesn't seem to appear in the flash area. Only the create message from (kanboard/app/Controller/ActionCreationController.php).
     if ($subtasksAdded > 0) {
       if ($subtasksAdded === 1) {
         $this->flash->success(t('Subtask added successfully.'));
@@ -109,7 +120,7 @@ class AutoCreateSubtaskVanilla extends Base
 
   public function hasRequiredCondition(array $data)
   {
-    
+
     if ($this->getParam('check_box_all_columns')) {
     return $data['task']['column_id'] == $data['task']['column_id'];
     } else {

--- a/Action/CategoryAutoSubtask.php
+++ b/Action/CategoryAutoSubtask.php
@@ -64,7 +64,7 @@ class CategoryAutoSubtask extends Base
 
     $subtasks = array_map('trim', explode("\r\n", isset($values['title']) ? $values['title'] : ''));
     $subtasksAdded = 0;
-    
+
     if ($this->getParam('check_box_no_duplicates') == true ){
       $current_subtasks = $this->subtaskModel->getAll($data['task_id']);
       foreach ($current_subtasks as $current_subtask) {
@@ -79,7 +79,22 @@ class CategoryAutoSubtask extends Base
 
       if (! empty($subtask)) {
         $subtaskValues = $values;
-        $subtaskValues['title'] = $subtask;
+
+        // *** Parsing for "magical" parameters ... enabling separate values for each subtask ***
+        // Extract subtask-title by ignoring all "magical" parameters
+        $subtaskValues['title'] = preg_replace('~.*?}~', '', $subtask);
+
+        // Extracting optional assignee for this subtask ELSE assignee from form will be used
+        $magic_user_id_exists = preg_match('/{u:(.*?)}/', $subtask, $magic_user_id);
+        $subtaskValues['user_id'] = ($magic_user_id_exists) ? $magic_user_id[1] : $subtaskValues['user_id'];
+
+        // Extracting optional estimated hours for this subtask ELSE estimated hours from form will be used
+        $magic_time_exists = preg_match('/{h:(.*?)}/', $subtask, $magic_time);
+        $subtaskValues['time_estimated'] = ($magic_time_exists) ? $magic_time[1] : $subtaskValues['time_estimated'];
+
+        // Extracting optional due date for this subtask ELSE due date from form will be used
+        $magic_days_exist = preg_match('/{d:(.*?)}/', $subtask, $magic_days);
+        $subtaskValues['due_date'] = ($magic_days_exist) ? strtotime('+'.$magic_days[1].'days') : $subtaskValues['due_date'];
 
         list($valid, $errors) = $this->subtaskValidator->validateCreation($subtaskValues);
 
@@ -97,7 +112,7 @@ class CategoryAutoSubtask extends Base
         $subtasksAdded++;
       }
     }
-    //restore the messaging with a flash but this message doesn't seem to appear in the flash area. Only the create message from (kanboard/app/Controller/ActionCreationController.php). 
+    //restore the messaging with a flash but this message doesn't seem to appear in the flash area. Only the create message from (kanboard/app/Controller/ActionCreationController.php).
     if ($subtasksAdded > 0) {
       if ($subtasksAdded === 1) {
         $this->flash->success(t('Subtask added successfully.'));

--- a/Plugin.php
+++ b/Plugin.php
@@ -14,16 +14,17 @@ class Plugin extends Base
   public function initialize()
 
   {
-    $this->template->setTemplateOverride('action_creation/params', 'autoSubtasks:action_creation/params');
-    
+
     if (file_exists('plugins/Subtaskdate')) {
+      $this->template->setTemplateOverride('action_creation/params', 'autoSubtasks:action_creation/params');
       $this->actionManager->register(new AutoCreateSubtask($this->container));
       $this->actionManager->register(new CategoryAutoSubtask($this->container));
     } else {
+      $this->template->setTemplateOverride('action_creation/params', 'autoSubtasks:action_creation/params_vanilla');
       $this->actionManager->register(new AutoCreateSubtaskVanilla($this->container));
       $this->actionManager->register(new CategoryAutoSubtaskVanilla($this->container));
     }
-    
+
   }
 
   public function getPluginName()
@@ -40,7 +41,7 @@ class Plugin extends Base
   {
     return '2.1.0';
   }
-  
+
   public function getPluginDescription()
   {
     return 'Adding automatic actions for subtasks';
@@ -50,7 +51,7 @@ class Plugin extends Base
   {
     return 'https://github.com/creecros/AutoSubtasks';
   }
-  
+
   public function getCompatibleVersion()
   {
     return '>=1.0.48';

--- a/Template/action_creation/params_vanilla.php
+++ b/Template/action_creation/params_vanilla.php
@@ -62,15 +62,14 @@
             <?= $this->form->textarea('params['.$param_name.']', $values) ?>
             <div class="form-help">
                 <?= t('Enter one line per task, or leave blank to copy Task Title and create only one subtask.') ?><br />
-                <?= t('You can use "magical" parameters on each line to set individual values for Assignee, Estimated Hours and Duration in days for any subtask.') ?><br />
+                <?= t('You can use "magical" parameters on each line to set individual values for Assignee and Estimated Hours for any subtask.') ?><br />
                 <?= t('--> Hover mouse over INFO-icon for help ...') ?><br />
                 <?php
                     $help_tooltip = t('HELP for useage of "magical" parameters:') . '&#10';
                     $help_tooltip .= t('- Prepending a line with {u:19} will assign that subtask to the user with user-id 19') . '&#10';
                     $help_tooltip .= t('- Prepending a line with {h:1.5} will set the estimatedhours for that subtask 1.5 hours') . '&#10';
-                    $help_tooltip .= t('- Prepending a line with {d:7} will set the duration in days for that subtask 7 days') . '&#10';
                     $help_tooltip .= t('-- You can use all combinations of "magical" parameters:') . '&#10';
-                    $help_tooltip .= t('--- None, only the {u:-parameter}, only the {h:-parameter}, only the {d:-parameter}, any 2 of them or all 3!');
+                    $help_tooltip .= t('--- None, only the {u:-parameter}, only the {h:-parameter} or both!');
                 ?>
                 <i class="fa fa-fw fa-info-circle fa-2x aria-hidden="true" title="<?= $help_tooltip; ?>"></i>
             </div>


### PR DESCRIPTION
Hey Craig,
I really like this plugin and funny enough, while testing it I had the same idea, that [you have mentioned over here some time ago](https://github.com/creecros/AutoSubtasks/issues/18) 

> I actually don't like the fact that you can't create 4 subtasks with 4 different assignees.

**So here's my approach to solve this _(and even add some more features)_**
While retaining the current input-form, when creating AutoSubtasks I have added what I call "magical" parameters, that can be used on each line to overwrite any of these 2 or 3 parameters :
- Assignee
- Estimated hours
- Duration in days _(depending on the coexistance of the Subtaskdate-plugin)_

**What are "magical" parameters?**
These parameters can _(optionally)_ be prepended to each line by wrappping them into curly braces:
- {u:user-id} assigns that subtask to the user with that user-.id
- {h:estimated-hours} assigns individual estimated hours to that subtask
- {d:duration-in-days} assigns individual duration-days to that subtask
 - Any combination of the 3 parameters can be used

**Pictures are worth a thousand words**
_The new options are explained, when hovering the mouse over the INFO-icon ..._
![AutoSubTask-with-magic-01](https://user-images.githubusercontent.com/48651533/77858161-fc33ac00-7201-11ea-8175-18f6cf1aab7d.png)

_Task with matching category has the SubTask created by the automatic action_
![AutoSubTask-with-magic-02](https://user-images.githubusercontent.com/48651533/77858186-1d949800-7202-11ea-82b9-537df7592e7f.png)

**ToDo**
- I did quite some testing, but maybe others_(you ?)_ are also willing to test this ...
- Need to add checks, to avoid subtasks to users that cannot access that board
  - In this case I would assign the task to the default assignee
- Whatever else I may have forgotten 

Looking forward to hear what you think of my idea.



